### PR TITLE
Synchronize rope sleep state across clients

### DIFF
--- a/src/PeakStranding/Patches/RopeOptimizer/RopeSegment_Interact_Patch.cs
+++ b/src/PeakStranding/Patches/RopeOptimizer/RopeSegment_Interact_Patch.cs
@@ -9,12 +9,10 @@ namespace PeakStranding.Patches
         {
             if (__instance.rope != null)
             {
+                // Wake the rope when a segment is interacted with. The sleep
+                // timer is managed on the master via RPC, so no additional
+                // local state changes are required here.
                 __instance.rope.WakeUp();
-                if (__instance.rope.photonView.IsMine)
-                {
-                    var data = __instance.rope.GetData();
-                    data.SleepCountdown = -1f;
-                }
             }
         }
     }

--- a/src/PeakStranding/Patches/RopeOptimizer/Rope_ExtendedData.cs
+++ b/src/PeakStranding/Patches/RopeOptimizer/Rope_ExtendedData.cs
@@ -27,6 +27,14 @@ namespace PeakStranding.Patches
         {
             var data = rope.GetData();
             if (data.IsSleeping) return;
+
+            // Update local state immediately to avoid duplicate RPCs before the
+            // network message is processed. The RPC will mirror this state on
+            // all other clients.
+            data.IsSleeping = true;
+            data.SleepCountdown = -1f;
+            data.WasBeingClimbed = false;
+
             rope.GetComponent<PhotonView>().RPC("EnterSleepState_RPC", RpcTarget.All);
         }
 
@@ -34,11 +42,13 @@ namespace PeakStranding.Patches
         {
             var data = rope.GetData();
             if (!data.IsSleeping) return;
-            
-            // Initialize sleep tracking state
+
+            // Initialize sleep tracking state locally. The RPC will propagate
+            // the same values to the rest of the clients.
+            data.IsSleeping = false;
             data.SleepCountdown = SleepDelay;
             data.WasBeingClimbed = false;
-            
+
             rope.GetComponent<PhotonView>().RPC("ExitSleepState_RPC", RpcTarget.All);
         }
 

--- a/src/PeakStranding/Patches/RopeOptimizer/Rope_SleepRPCs.cs
+++ b/src/PeakStranding/Patches/RopeOptimizer/Rope_SleepRPCs.cs
@@ -15,6 +15,7 @@ namespace PeakStranding.Patches
             var data = rope.GetData();
             data.IsSleeping = true;
             data.SleepCountdown = -1f;
+            data.WasBeingClimbed = false;
 
             var segments = (List<Transform>)AccessTools.Field(typeof(Rope), "simulationSegments").GetValue(rope);
             if (photonView.IsMine)
@@ -34,6 +35,8 @@ namespace PeakStranding.Patches
         {
             var data = rope.GetData();
             data.IsSleeping = false;
+            data.SleepCountdown = Rope_ExtendedData.SleepDelay;
+            data.WasBeingClimbed = false;
 
             var segments = (List<Transform>)AccessTools.Field(typeof(Rope), "simulationSegments").GetValue(rope);
             if (photonView.IsMine)


### PR DESCRIPTION
## Summary
- ensure local rope sleep state updates before sending RPCs
- synchronize sleep countdown and climb flags in sleep/wake RPC handlers
- simplify rope interaction patch to avoid unsynced sleep timer changes

## Testing
- `dotnet build` *(fails: Photon/other assemblies missing)*

------
https://chatgpt.com/codex/tasks/task_e_68953ff3a20083248ebaf304734245ca